### PR TITLE
refactor(ui): refresh TUI theme

### DIFF
--- a/src/renux/app.py
+++ b/src/renux/app.py
@@ -10,7 +10,7 @@ from renux.components import Form, Preview
 from renux.constants import DEFAULT_OPTIONS
 from renux.helpers.files import get_files
 from renux.renamer import apply_renames, get_renames
-from renux.ui import CSS_PATH
+from renux.ui import CSS_PATH, THEME
 
 
 class RenameApp(App):
@@ -44,7 +44,8 @@ class RenameApp(App):
         self.disabled_files: list[str] = []
 
     def on_mount(self) -> None:
-        self.theme = "textual-dark"
+        self.register_theme(THEME)
+        self.theme = THEME.name
         # Focus on the first input field
         self.query_one("#pattern", Input).focus()
 

--- a/src/renux/app.py
+++ b/src/renux/app.py
@@ -10,7 +10,7 @@ from renux.components import Form, Preview
 from renux.constants import DEFAULT_OPTIONS
 from renux.helpers.files import get_files
 from renux.renamer import apply_renames, get_renames
-from renux.ui import CSS_PATH, THEME
+from renux.ui import CSS_PATH
 
 
 class RenameApp(App):
@@ -44,8 +44,7 @@ class RenameApp(App):
         self.disabled_files: list[str] = []
 
     def on_mount(self) -> None:
-        self.register_theme(THEME)
-        self.theme = "gruvbox"
+        self.theme = "textual-dark"
         # Focus on the first input field
         self.query_one("#pattern", Input).focus()
 

--- a/src/renux/assets/styles.tcss
+++ b/src/renux/assets/styles.tcss
@@ -6,6 +6,9 @@
 
 #form-column {
   width: 1fr;
+  border: round $secondary;
+  padding: 1;
+  margin: 1;
 }
 
 #form-column > Container {
@@ -14,18 +17,15 @@
 
 #preview-column {
   width: 1.5fr;
+  border: round $secondary;
+  padding: 1;
+  margin: 1;
 }
 
 #form {
   height: auto;
   padding-right: 1;
   padding-left: 1;
-}
-
-#preview {
-  border: round $secondary;
-  padding: 1;
-  margin: 1;
 }
 
 Header {

--- a/src/renux/assets/styles.tcss
+++ b/src/renux/assets/styles.tcss
@@ -8,11 +8,16 @@
   width: 1fr;
 }
 
+#form-column > Container {
+  height: auto;
+}
+
 #preview-column {
   width: 1.5fr;
 }
 
 #form {
+  height: auto;
   padding-right: 1;
   padding-left: 1;
 }

--- a/src/renux/assets/styles.tcss
+++ b/src/renux/assets/styles.tcss
@@ -23,7 +23,7 @@
 }
 
 #preview {
-  border: round $primary;
+  border: round $secondary;
   padding: 1;
   margin: 1;
 }

--- a/src/renux/cli.py
+++ b/src/renux/cli.py
@@ -2,7 +2,7 @@ import os
 
 from renux.app import RenameApp
 from renux.parser import parse_args
-from renux.ui import CONSOLE, THEME
+from renux.ui import CONSOLE
 
 
 def main() -> None:
@@ -12,7 +12,7 @@ def main() -> None:
 
     directory = args.directory
     if not os.path.isdir(directory):
-        CONSOLE.print(f"Directory `{directory}` does not exist.", style=THEME.error)
+        CONSOLE.print(f"Directory `{directory}` does not exist.", style="red")
         return
     pattern = args.pattern
     replacement = args.replacement

--- a/src/renux/components/form.py
+++ b/src/renux/components/form.py
@@ -1,7 +1,6 @@
 import os
 from typing import TYPE_CHECKING
 
-from rich.highlighter import RegexHighlighter
 from textual.containers import Horizontal
 from textual.suggester import SuggestFromList
 from textual.validation import Number
@@ -9,6 +8,7 @@ from textual.widget import Widget
 from textual.widgets import Checkbox, Input, Label, Select
 
 from renux.constants import APPLY_TO_OPTIONS
+from renux.helpers.highlighter import TokenHighlighter
 from renux.helpers.keywords import get_keywords
 
 if TYPE_CHECKING:
@@ -21,12 +21,19 @@ class Form(Widget):
     app: "RenameApp"
 
     def compose(self):
+        theme = self.app.current_theme
+        highlighter = TokenHighlighter(
+            keyword=theme.accent,
+            operation=theme.primary,
+            punctuation="dim",
+        )
+
         yield Input(
             id="pattern",
             value=self.app.pattern,
             placeholder="Search for",
             compact=True,
-            highlighter=RegexHighlighter(),
+            highlighter=highlighter,
             suggester=SuggestFromList(self.app.files, case_sensitive=False),
         )
         yield Input(
@@ -34,6 +41,7 @@ class Form(Widget):
             value=self.app.replacement,
             placeholder="Replace with",
             compact=True,
+            highlighter=highlighter,
             suggester=SuggestFromList(
                 self.app.files + get_keywords(), case_sensitive=False
             ),

--- a/src/renux/components/preview.py
+++ b/src/renux/components/preview.py
@@ -5,7 +5,6 @@ from textual.widget import Widget
 from textual.widgets import Tree
 
 from renux.renamer import get_renames
-from renux.ui import THEME
 
 if TYPE_CHECKING:
     from renux.app import RenameApp
@@ -36,17 +35,18 @@ class Preview(Widget):
             self.app.options,
         )
 
+        theme = self.app.current_theme
         self._tree.root.remove_children()
         for old, new in renames:
             disabled = old in self.app.disabled_files
             text = Text()
             text.append(
-                "▢ " if disabled else "▣ ", "dim" if disabled else THEME.primary
+                "▢ " if disabled else "▣ ", "dim" if disabled else theme.primary
             )
-            text.append(old, "dim" if disabled else THEME.foreground)
+            text.append(old, "dim" if disabled else theme.foreground)
             if old != new:
                 text.append(" → ", "dim bold"),
-                text.append(new, str("dim" if disabled else THEME.primary) + " bold"),
+                text.append(new, ("dim" if disabled else theme.primary) + " bold"),
 
             self._tree.root.add_leaf(text, data=old)
 

--- a/src/renux/helpers/highlighter.py
+++ b/src/renux/helpers/highlighter.py
@@ -1,0 +1,35 @@
+import re
+
+from rich.highlighter import Highlighter
+from rich.text import Text
+
+from renux.constants import COUNTER_KEYWORD, DATE_KEYWORDS, TEXT_OPERATIONS
+
+_KEYWORDS = "|".join(
+    re.escape(keyword) for keyword in [COUNTER_KEYWORD, *DATE_KEYWORDS]
+)
+_OPERATIONS = "|".join(re.escape(operation) for operation in TEXT_OPERATIONS)
+
+TOKEN_PATTERN = re.compile(
+    r"(?P<punctuation>[{}()])"
+    rf"|(?P<keyword>\b(?:{_KEYWORDS})\b)"
+    rf"|(?P<operation>\|(?:{_OPERATIONS})\b)"
+)
+
+
+class TokenHighlighter(Highlighter):
+    """Highlights renux's placeholder syntax, e.g. `{counter()}`, `{now(%Y)}`, `{name|upper}`."""
+
+    def __init__(self, keyword: str, operation: str, punctuation: str = "dim") -> None:
+        self.styles = {
+            "punctuation": punctuation,
+            "keyword": keyword,
+            "operation": operation,
+        }
+        super().__init__()
+
+    def highlight(self, text: Text) -> None:
+        for match in TOKEN_PATTERN.finditer(text.plain):
+            group = match.lastgroup
+            if group is not None:
+                text.stylize(self.styles[group], *match.span())

--- a/src/renux/ui.py
+++ b/src/renux/ui.py
@@ -1,9 +1,27 @@
+import dataclasses
 from importlib.resources import files
 
 from rich.console import Console
+from textual.theme import BUILTIN_THEMES
 
 # Path to the CSS file
 CSS_PATH = files("renux.assets").joinpath("styles.tcss")
+
+# Custom Textual theme, based on the built-in "textual-dark" theme with a
+# minimal set of overrides for a near-black, neutral grayscale palette
+# (inspired by Vercel/shadcn-ui), keeping vibrant color reserved for
+# semantic states (focus, selection, errors, warnings, success).
+THEME = dataclasses.replace(
+    BUILTIN_THEMES["textual-dark"],
+    name="renux",
+    primary="#e4e4e7",
+    secondary="#52525b",
+    accent="#e4e4e7",
+    foreground="#fafafa",
+    background="#0a0a0a",
+    surface="#111113",
+    panel="#18181b",
+)
 
 # Rich console
 CONSOLE = Console()

--- a/src/renux/ui.py
+++ b/src/renux/ui.py
@@ -1,30 +1,9 @@
 from importlib.resources import files
 
 from rich.console import Console
-from textual.theme import Theme
 
 # Path to the CSS file
 CSS_PATH = files("renux.assets").joinpath("styles.tcss")
-
-# Textual Theme
-THEME = Theme(
-    name="gruvbox",
-    primary="#85A598",
-    secondary="#A89A85",
-    warning="#fabd2f",
-    error="#fb4934",
-    success="#b8bb26",
-    accent="#fabd2f",
-    foreground="#fbf1c7",
-    background="#282828",
-    surface="#3c3836",
-    panel="#504945",
-    dark=True,
-    variables={
-        "block-cursor-foreground": "#fbf1c7",
-        "input-selection-background": "#689d6a40",
-    },
-)
 
 # Rich console
 CONSOLE = Console()


### PR DESCRIPTION
Closes #37

## What

- Switch the default theme to Textual's built-in `textual-dark`, then register it as our own `renux` theme (cloned from `textual-dark`'s values) so it can be customized later without touching Textual internals.
- Apply a minimal, near-black neutral grayscale palette, keeping color reserved for semantic states (focus, selection, errors, warnings, success).
- Fix the left panel always showing a scrollbar even when its content fit the available height.
- Box both the left and right panels with a matching outline so they're aligned and visually balanced.
- Add syntax highlighting for renux's placeholder syntax (`{counter()}`, `{now()}`, `{name|upper}`, etc.) in the pattern and replacement inputs.

## Why

The TUI carried a hardcoded Gruvbox theme and several CSS overrides that only existed to enforce that look, a layout bug that always left a spurious scrollbar on the left panel, and no visual distinction for the tool's placeholder syntax while typing. This brings the UI closer to native Textual styling and makes the placeholder syntax easier to read at a glance.