### PR TITLE
docs: add AGENTS.md and agent skills

### DIFF
--- a/.agents/skills/add-tag/SKILL.md
+++ b/.agents/skills/add-tag/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: add-tag
+description: Scaffold a new renux tag placeholder or filter (e.g. "{counter}" or "{name|upper}"), keeping the registry, README, and tests in sync. Use when asked to add a new placeholder or filter to renux.
+---
+
+# add-tag
+
+Adds a new `{placeholder}` or `{value|filter}` to renux. The registry in
+`src/renux/tags.py` is the single source of truth. README docs and
+autocomplete are generated from it, so registering it correctly there is
+almost the whole job.
+
+## Steps
+
+1. Read `src/renux/tags.py` to see the `Placeholder`/`Filter` dataclasses and
+   a couple of existing `register_placeholder`/`register_filter` calls for
+   the pattern to follow.
+2. Add the new placeholder or filter:
+   - **Placeholder**: needs `name`, `description`, `syntax`, a `resolve`
+     function taking `PlaceholderContext`, `category`, and ideally an
+     `example` and suggested `(args)` strings for autocomplete.
+   - **Filter**: needs `name`, `func` (`str -> str`), and `description`.
+3. If the resolve/filter logic is non-trivial, put it in
+   `src/renux/helpers/` (see `helpers/casing.py` for the existing pattern)
+   and import it into `tags.py`.
+4. Add a test case in `tests/test_tags.py` covering the new placeholder or
+   filter (normal input, and any edge case like empty args or empty string).
+5. Regenerate the README's auto-generated tags section:
+   ```sh
+   poetry run python scripts/sync_readme.py
+   ```
+   This rewrites the block between `<!-- TAGS:START -->` and
+   `<!-- TAGS:END -->`. Do not hand-edit that block.
+6. Run the full check before considering it done:
+   ```sh
+   poetry run pytest
+   poetry run mypy src
+   ```
+
+## Don't
+
+- Don't hand-edit the README's tags block. It's overwritten by
+  `sync_readme.py` and by the `sync-readme` pre-commit hook.
+- Don't duplicate placeholder/filter docs anywhere else; everything derives
+  from `tags.py` via `src/renux/tags_reference.py`.

--- a/.agents/skills/pre-flight/SKILL.md
+++ b/.agents/skills/pre-flight/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: pre-flight
+description: Run renux's full pre-commit checklist (tests, type check, format, lint, README sync) before committing. Use before committing changes or when asked to check/verify the repo is ready to commit.
+---
+
+# pre-flight
+
+Runs the same checks CI and the pre-commit hooks enforce, so problems are
+caught before a commit attempt fails partway through.
+
+## Steps
+
+Run in order, fixing failures as you go:
+
+1. Tests
+   ```sh
+   poetry run pytest
+   ```
+2. Type check
+   ```sh
+   poetry run mypy src
+   ```
+3. Format and lint
+   ```sh
+   poetry run black .
+   poetry run isort .
+   ```
+4. README sync. Required if `src/renux/tags.py` or
+   `src/renux/tags_reference.py` changed:
+   ```sh
+   poetry run python scripts/sync_readme.py
+   ```
+   If it prints "README.md tags reference updated.", re-stage README.md.
+5. Re-check `git status`/`git diff` for anything the above steps modified
+   (formatting, README) before committing.
+
+## Notes
+
+- Commit messages must follow Conventional Commits (enforced by the
+  commitizen `commit-msg` hook).
+  Use `poetry run cz commit` for a guided prompt if unsure.
+- Don't bypass any of this with `git commit --no-verify`.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: release
+description: Cut a new renux release using commitizen (version bump derived from Conventional Commits history, git tag, build). Use when asked to release, bump the version, or cut a new version of renux.
+---
+
+# release
+
+renux's version is derived from git tags via commitizen
+(`version_provider = "pep621"`, `tag_format = "v$version"` in
+`pyproject.toml`). Never hand-edit the version in `pyproject.toml` or
+`src/renux/__init__.py`. Always go through `cz bump`.
+
+## Steps
+
+1. Make sure the working tree is clean and you're on `main`, up to date with
+   `origin/main`.
+2. Confirm tests and type checks pass:
+   ```sh
+   poetry run pytest
+   poetry run mypy src
+   ```
+3. Preview the version bump before doing it for real:
+   ```sh
+   poetry run cz bump --dry-run
+   ```
+   This inspects Conventional Commits history since the last tag to decide
+   patch/minor/major. Confirm the proposed version looks right.
+4. Run the real bump (updates version in `pyproject.toml`, updates
+   changelog, commits, and creates the `vX.Y.Z` tag):
+   ```sh
+   poetry run cz bump
+   ```
+5. Confirm with the user before pushing. Pushing tags/commits is a
+   shared-state action:
+   ```sh
+   git push origin main --tags
+   ```
+6. Build the distributable if needed:
+   ```sh
+   poetry build
+   ```
+
+## Don't
+
+- Don't manually edit the version number anywhere. It's commitizen's job.
+- Don't force-push or delete/re-tag an already-pushed version tag.
+- Don't skip the dry run. A stray `feat:`/`fix!:` commit in history can
+  cause a bigger bump than expected.

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,10 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# AI tools
+.claude
+.codex
+.cursor
+.cursorrules
+.gemini

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+Notes for agents working on renux (TUI bulk file renamer).
+
+## Layout
+
+- `src/renux/tags.py` - placeholder/filter registry (see above)
+- `src/renux/parser.py` - resolves tag strings against filenames
+- `src/renux/renamer.py` - actual rename/apply logic
+- `src/renux/backup.py` - undo/backup support for applied renames
+- `src/renux/app.py`, `screens/`, `components/` - Textual TUI
+- `src/renux/cli.py` - CLI entrypoint (`renux` console script)
+
+## Testing
+
+`poetry run pytest` and `poetry run mypy src` before considering a change done.
+Both are also enforced in CI/preqcommit.
+
+## Tags registry is the source of truth
+
+`src/renux/tags.py` is a single registry for every `{placeholder}` and `{value|filter}`.
+Adding/changing a placeholder or filter there is enough.
+Docs, autocomplete, and README all derive from it via `src/renux/tags_reference.py`.
+Don't hand-edit the tag docs elsewhere.


### PR DESCRIPTION
## What

- Add `AGENTS.md` documenting non-obvious project conventions
- Add `.agents/skills/` with `add-tag`, `release`, and `pre-flight` skills
- gitignore agent-tool-specific dirs/files
