### PR TITLE
feat: add headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ renux [directory] [pattern] [replacement]
   - `name`: Rename the file's base name (default).
   - `ext`: Rename the file's extension.
   - `both`: Rename both the name and extension.
+- `-y`, `--yes`: Apply the rename immediately without opening the TUI
+  (headless mode, useful for scripts/CI).
+- `--dry-run`: Preview the rename without opening the TUI or changing any
+  files (headless mode).
 
 **Tags**
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ renux [directory] [pattern] [replacement]
   e.g. `README.md`, `*.log`). Repeatable, e.g.
   `--exclude README.md --exclude Dockerfile`. In the TUI, this is a
   comma-separated field in the form.
+
+  Patterns are evaluated in order, gitignore-style: prefix a pattern with `!`
+  to re-include a file matched by an earlier pattern, e.g.
+  `--exclude "*.txt" --exclude "!foo1.txt"` excludes all `.txt` files except
+  `foo1.txt`.
 - `-y`, `--yes`: Apply the rename immediately without opening the TUI
   (headless mode, useful for scripts/CI).
 - `--dry-run`: Preview the rename without opening the TUI or changing any

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ renux [directory] [pattern] [replacement]
   (headless mode, useful for scripts/CI).
 - `--dry-run`: Preview the rename without opening the TUI or changing any
   files (headless mode).
+- `--undo`: Undo the last rename applied to `directory` without opening the
+  TUI (headless mode).
+- `--redo`: Redo the last undone rename in `directory` without opening the
+  TUI (headless mode).
 
 **Tags**
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ renux [directory] [pattern] [replacement]
   - `name`: Rename the file's base name (default).
   - `ext`: Rename the file's extension.
   - `both`: Rename both the name and extension.
+- `--exclude PATTERN`: Exclude files matching `PATTERN` (exact name or glob,
+  e.g. `README.md`, `*.log`). Repeatable, e.g.
+  `--exclude README.md --exclude Dockerfile`. In the TUI, this is a
+  comma-separated field in the form.
 - `-y`, `--yes`: Apply the rename immediately without opening the TUI
   (headless mode, useful for scripts/CI).
 - `--dry-run`: Preview the rename without opening the TUI or changing any

--- a/src/renux/app.py
+++ b/src/renux/app.py
@@ -8,7 +8,7 @@ from renux.backup import load_backup, save_backup
 from renux.bindings import BINDINGS
 from renux.components import Form, Preview
 from renux.constants import DEFAULT_OPTIONS
-from renux.helpers.files import get_files
+from renux.helpers.files import get_files, is_excluded
 from renux.renamer import apply_renames, get_renames
 from renux.screens import HelpScreen
 from renux.ui import CSS_PATH, THEME
@@ -26,6 +26,7 @@ class RenameApp(App):
         pattern: str = "",
         replacement: str = "",
         options: dict[str, str | int | bool] = DEFAULT_OPTIONS.copy(),
+        exclude: str = "",
         *args,
         **kwargs,
     ):
@@ -40,9 +41,15 @@ class RenameApp(App):
         self.pattern = pattern
         self.replacement = replacement
         self.options = options
+        self.exclude = exclude
 
         self.files = get_files(directory)
         self.disabled_files: list[str] = []
+
+    def is_excluded(self, file_name: str) -> bool:
+        """Check if `file_name` matches a pattern in the exclude field."""
+        patterns = [p.strip() for p in self.exclude.split(",") if p.strip()]
+        return is_excluded(file_name, patterns)
 
     def on_mount(self) -> None:
         self.register_theme(THEME)
@@ -91,8 +98,10 @@ class RenameApp(App):
         self.pattern = ""
         self.replacement = ""
         self.options = DEFAULT_OPTIONS.copy()
+        self.exclude = ""
         self.query_one("#pattern", Input).value = ""
         self.query_one("#replacement", Input).value = ""
+        self.query_one("#exclude", Input).value = ""
         self.query_one("#count", Input).value = str(DEFAULT_OPTIONS["count"])
         self.query_one("#regex", Checkbox).value = bool(DEFAULT_OPTIONS["regex"])
         self.query_one("#case_sensitive", Checkbox).value = bool(
@@ -101,7 +110,11 @@ class RenameApp(App):
         self.query_one("#apply_to", Select).value = DEFAULT_OPTIONS["apply_to"]
 
     def action_save(self) -> None:
-        files = [file for file in self.files if file not in self.disabled_files]
+        files = [
+            file
+            for file in self.files
+            if file not in self.disabled_files and not self.is_excluded(file)
+        ]
         try:
             renames = get_renames(
                 files, self.directory, self.pattern, self.replacement, self.options

--- a/src/renux/cli.py
+++ b/src/renux/cli.py
@@ -40,6 +40,47 @@ def run_headless(
     CONSOLE.print(f"Renamed {len(changed)} file(s).", style="green")
 
 
+def run_undo(directory: str) -> None:
+    """Undo the last rename applied to `directory` without opening the TUI."""
+    undo_stack, redo_stack = load_backup(directory)
+
+    if not undo_stack:
+        CONSOLE.print("Nothing to undo.", style="yellow")
+        return
+
+    last_renames = undo_stack.pop()
+
+    try:
+        reversed_renames = [(new, old) for old, new in last_renames]
+        apply_renames(directory, reversed_renames)
+        redo_stack.append(last_renames)
+        CONSOLE.print("Undo successful.", style="green")
+    except Exception as e:
+        CONSOLE.print(f"Undo failed: {e}", style="red")
+
+    save_backup(directory, undo_stack, redo_stack)
+
+
+def run_redo(directory: str) -> None:
+    """Redo the last undone rename in `directory` without opening the TUI."""
+    undo_stack, redo_stack = load_backup(directory)
+
+    if not redo_stack:
+        CONSOLE.print("Nothing to redo.", style="yellow")
+        return
+
+    renames = redo_stack.pop()
+
+    try:
+        apply_renames(directory, renames)
+        undo_stack.append(renames)
+        CONSOLE.print("Redo successful.", style="green")
+    except Exception as e:
+        CONSOLE.print(f"Redo failed: {e}", style="red")
+
+    save_backup(directory, undo_stack, redo_stack)
+
+
 def main() -> None:
     """Main entry point of the script."""
     # Parse command-line arguments
@@ -49,6 +90,14 @@ def main() -> None:
     if not os.path.isdir(directory):
         CONSOLE.print(f"Directory `{directory}` does not exist.", style="red")
         return
+    # Headless mode: undo/redo the last rename directly and exit, no TUI
+    if args.undo:
+        run_undo(directory)
+        return
+    if args.redo:
+        run_redo(directory)
+        return
+
     pattern = args.pattern
     replacement = args.replacement
     options = {

--- a/src/renux/cli.py
+++ b/src/renux/cli.py
@@ -2,17 +2,22 @@ import os
 
 from renux.app import RenameApp
 from renux.backup import load_backup, save_backup
-from renux.helpers.files import get_files
+from renux.helpers.files import filter_excluded, get_files
 from renux.parser import parse_args
 from renux.renamer import apply_renames, get_renames
 from renux.ui import CONSOLE
 
 
 def run_headless(
-    directory: str, pattern: str, replacement: str, options: dict, dry_run: bool
+    directory: str,
+    pattern: str,
+    replacement: str,
+    options: dict,
+    dry_run: bool,
+    exclude: list[str] | None = None,
 ) -> None:
     """Compute and (unless dry-run) apply renames without opening the TUI."""
-    files = get_files(directory)
+    files = filter_excluded(get_files(directory), exclude or [])
     renames = get_renames(files, directory, pattern, replacement, options)
     changed = [(old, new) for old, new in renames if old != new]
 
@@ -109,12 +114,23 @@ def main() -> None:
 
     # Headless mode: apply/preview the rename directly and exit, no TUI
     if args.yes or args.dry_run:
-        run_headless(directory, pattern, replacement, options, dry_run=args.dry_run)
+        run_headless(
+            directory,
+            pattern,
+            replacement,
+            options,
+            dry_run=args.dry_run,
+            exclude=args.exclude,
+        )
         return
 
     # Run the app
     app = RenameApp(
-        directory=directory, pattern=pattern, replacement=replacement, options=options
+        directory=directory,
+        pattern=pattern,
+        replacement=replacement,
+        options=options,
+        exclude=", ".join(args.exclude) if args.exclude else "",
     )
     app.run()
 

--- a/src/renux/cli.py
+++ b/src/renux/cli.py
@@ -1,8 +1,43 @@
 import os
 
 from renux.app import RenameApp
+from renux.backup import load_backup, save_backup
+from renux.helpers.files import get_files
 from renux.parser import parse_args
+from renux.renamer import apply_renames, get_renames
 from renux.ui import CONSOLE
+
+
+def run_headless(
+    directory: str, pattern: str, replacement: str, options: dict, dry_run: bool
+) -> None:
+    """Compute and (unless dry-run) apply renames without opening the TUI."""
+    files = get_files(directory)
+    renames = get_renames(files, directory, pattern, replacement, options)
+    changed = [(old, new) for old, new in renames if old != new]
+
+    if not changed:
+        CONSOLE.print("No files to rename.", style="yellow")
+        return
+
+    for old_name, new_name in changed:
+        CONSOLE.print(f"{old_name} -> {new_name}")
+
+    if dry_run:
+        return
+
+    try:
+        apply_renames(directory, renames)
+    except ValueError as e:
+        CONSOLE.print(str(e), style="red")
+        return
+
+    undo_stack, redo_stack = load_backup(directory)
+    undo_stack.append(renames)
+    redo_stack.clear()
+    save_backup(directory, undo_stack, redo_stack)
+
+    CONSOLE.print(f"Renamed {len(changed)} file(s).", style="green")
 
 
 def main() -> None:
@@ -22,6 +57,11 @@ def main() -> None:
         "case_sensitive": args.case_sensitive,
         "apply_to": args.apply_to,
     }
+
+    # Headless mode: apply/preview the rename directly and exit, no TUI
+    if args.yes or args.dry_run:
+        run_headless(directory, pattern, replacement, options, dry_run=args.dry_run)
+        return
 
     # Run the app
     app = RenameApp(

--- a/src/renux/components/form.py
+++ b/src/renux/components/form.py
@@ -45,6 +45,14 @@ class Form(Widget):
             suggester=TagSuggester(self.app.files, case_sensitive=False),
             classes="mb",
         )
+        yield Input(
+            id="exclude",
+            value=self.app.exclude,
+            placeholder="Exclude files (comma-separated)",
+            compact=True,
+            suggester=SuggestFromList(self.app.files, case_sensitive=False),
+            classes="mb",
+        )
 
         yield Label(
             "[bold]Options[/bold]",
@@ -83,7 +91,7 @@ class Form(Widget):
         )
 
     def on_input_changed(self, event: Input.Changed) -> None:
-        if event.input.id in ("pattern", "replacement"):
+        if event.input.id in ("pattern", "replacement", "exclude"):
             setattr(self.app, event.input.id, event.value)
         elif event.input.id == "count":
             self.app.options["count"] = int(event.value or "0")

--- a/src/renux/components/preview.py
+++ b/src/renux/components/preview.py
@@ -38,7 +38,7 @@ class Preview(Widget):
         theme = self.app.current_theme
         self._tree.root.remove_children()
         for old, new in renames:
-            disabled = old in self.app.disabled_files
+            disabled = old in self.app.disabled_files or self.app.is_excluded(old)
             text = Text()
             text.append(
                 "▢ " if disabled else "▣ ", "dim" if disabled else theme.primary

--- a/src/renux/helpers/files.py
+++ b/src/renux/helpers/files.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 
 
@@ -11,3 +12,16 @@ def get_files(directory: str) -> list[str]:
         ],
         key=lambda name: name.lower(),
     )
+
+
+def is_excluded(file_name: str, patterns: list[str]) -> bool:
+    """Check whether `file_name` matches any of the given exclude patterns
+    (exact names or globs, e.g. `README.md`, `*.log`)."""
+    return any(fnmatch.fnmatch(file_name, pattern) for pattern in patterns)
+
+
+def filter_excluded(files: list[str], patterns: list[str]) -> list[str]:
+    """Return `files` with any entries matching an exclude pattern removed."""
+    if not patterns:
+        return files
+    return [f for f in files if not is_excluded(f, patterns)]

--- a/src/renux/helpers/files.py
+++ b/src/renux/helpers/files.py
@@ -16,8 +16,20 @@ def get_files(directory: str) -> list[str]:
 
 def is_excluded(file_name: str, patterns: list[str]) -> bool:
     """Check whether `file_name` matches any of the given exclude patterns
-    (exact names or globs, e.g. `README.md`, `*.log`)."""
-    return any(fnmatch.fnmatch(file_name, pattern) for pattern in patterns)
+    (exact names or globs, e.g. `README.md`, `*.log`).
+
+    Patterns are evaluated in order, gitignore-style: a pattern prefixed with
+    `!` re-includes a file that matched an earlier pattern, so later patterns
+    take precedence (e.g. `["*.txt", "!foo1.txt"]` excludes all `.txt` files
+    except `foo1.txt`)."""
+    excluded = False
+    for pattern in patterns:
+        if pattern.startswith("!"):
+            if fnmatch.fnmatch(file_name, pattern[1:]):
+                excluded = False
+        elif fnmatch.fnmatch(file_name, pattern):
+            excluded = True
+    return excluded
 
 
 def filter_excluded(files: list[str], patterns: list[str]) -> list[str]:

--- a/src/renux/parser.py
+++ b/src/renux/parser.py
@@ -70,6 +70,13 @@ def parse_args() -> Namespace:
         help=f"Specifies where the renaming should be applied (default: {DEFAULT_OPTIONS['apply_to']}).",
     )
     parser.add_argument(
+        "--exclude",
+        action="append",
+        metavar="PATTERN",
+        default=None,
+        help="Exclude files matching PATTERN (exact name or glob, e.g. `README.md`, `*.log`). Repeatable.",
+    )
+    parser.add_argument(
         "-y",
         "--yes",
         action="store_true",

--- a/src/renux/parser.py
+++ b/src/renux/parser.py
@@ -74,7 +74,7 @@ def parse_args() -> Namespace:
         action="append",
         metavar="PATTERN",
         default=None,
-        help="Exclude files matching PATTERN (exact name or glob, e.g. `README.md`, `*.log`). Repeatable.",
+        help="Exclude files matching PATTERN (exact name or glob, e.g. `README.md`, `*.log`). Repeatable; prefix with `!` to re-include a file matched by an earlier pattern.",
     )
     parser.add_argument(
         "-y",

--- a/src/renux/parser.py
+++ b/src/renux/parser.py
@@ -80,5 +80,15 @@ def parse_args() -> Namespace:
         action="store_true",
         help="Preview the rename without opening the TUI or changing any files (headless mode).",
     )
+    parser.add_argument(
+        "--undo",
+        action="store_true",
+        help="Undo the last rename applied to `directory` without opening the TUI (headless mode).",
+    )
+    parser.add_argument(
+        "--redo",
+        action="store_true",
+        help="Redo the last undone rename in `directory` without opening the TUI (headless mode).",
+    )
 
     return parser.parse_args()

--- a/src/renux/parser.py
+++ b/src/renux/parser.py
@@ -69,5 +69,16 @@ def parse_args() -> Namespace:
         default=DEFAULT_OPTIONS["apply_to"],
         help=f"Specifies where the renaming should be applied (default: {DEFAULT_OPTIONS['apply_to']}).",
     )
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Apply the rename immediately without opening the TUI (headless mode).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the rename without opening the TUI or changing any files (headless mode).",
+    )
 
     return parser.parse_args()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,3 +114,28 @@ def test_headless_exclude_skips_matching_files(tmp_path, monkeypatch):
         "bar1.txt",
         "bar2.txt",
     ]
+
+
+def test_headless_exclude_negation_reincludes_file(tmp_path, monkeypatch):
+    """A `!`-prefixed exclude pattern should re-include a file matched by an
+    earlier pattern, gitignore-style."""
+    _make_files(tmp_path, ["foo1.txt", "foo2.txt", "foo3.txt"])
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "renux",
+            str(tmp_path),
+            "foo",
+            "bar",
+            "--yes",
+            "--exclude",
+            "*.txt",
+            "--exclude",
+            "!foo1.txt",
+        ],
+    )
+
+    main()
+
+    assert sorted(os.listdir(tmp_path)) == ["bar1.txt", "foo2.txt", "foo3.txt"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,3 +85,32 @@ def test_headless_redo_nothing_to_redo(tmp_path, monkeypatch, capsys):
     main()
 
     assert "Nothing to redo." in capsys.readouterr().out
+
+
+def test_headless_exclude_skips_matching_files(tmp_path, monkeypatch):
+    """`--exclude` should skip files matching an exact name or glob pattern."""
+    _make_files(tmp_path, ["README.md", "Dockerfile", "foo1.txt", "foo2.txt"])
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "renux",
+            str(tmp_path),
+            "foo",
+            "bar",
+            "--yes",
+            "--exclude",
+            "README.md",
+            "--exclude",
+            "Dockerfile",
+        ],
+    )
+
+    main()
+
+    assert sorted(os.listdir(tmp_path)) == [
+        "Dockerfile",
+        "README.md",
+        "bar1.txt",
+        "bar2.txt",
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,3 +39,49 @@ def test_headless_no_matches(tmp_path, monkeypatch):
     main()
 
     assert sorted(os.listdir(tmp_path)) == ["baz.txt"]
+
+
+def test_headless_undo_reverts_last_rename(tmp_path, monkeypatch):
+    """`--undo` should revert the last headless rename without opening the TUI."""
+    _make_files(tmp_path, ["foo1.txt", "foo2.txt"])
+
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "foo", "bar", "--yes"])
+    main()
+    assert sorted(os.listdir(tmp_path)) == ["bar1.txt", "bar2.txt"]
+
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "--undo"])
+    main()
+    assert sorted(os.listdir(tmp_path)) == ["foo1.txt", "foo2.txt"]
+
+
+def test_headless_redo_reapplies_last_undo(tmp_path, monkeypatch):
+    """`--redo` should reapply the last headless undo without opening the TUI."""
+    _make_files(tmp_path, ["foo1.txt", "foo2.txt"])
+
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "foo", "bar", "--yes"])
+    main()
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "--undo"])
+    main()
+    assert sorted(os.listdir(tmp_path)) == ["foo1.txt", "foo2.txt"]
+
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "--redo"])
+    main()
+    assert sorted(os.listdir(tmp_path)) == ["bar1.txt", "bar2.txt"]
+
+
+def test_headless_undo_nothing_to_undo(tmp_path, monkeypatch, capsys):
+    """`--undo` with an empty undo stack should report and not error."""
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "--undo"])
+
+    main()
+
+    assert "Nothing to undo." in capsys.readouterr().out
+
+
+def test_headless_redo_nothing_to_redo(tmp_path, monkeypatch, capsys):
+    """`--redo` with an empty redo stack should report and not error."""
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "--redo"])
+
+    main()
+
+    assert "Nothing to redo." in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import os
+
+from renux.cli import main
+
+
+def _make_files(tmp_path, names):
+    for name in names:
+        (tmp_path / name).touch()
+
+
+def test_headless_dry_run_does_not_rename(tmp_path, monkeypatch):
+    """`--dry-run` should preview the rename without touching any files."""
+    _make_files(tmp_path, ["foo1.txt", "foo2.txt"])
+
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "foo", "bar", "--dry-run"])
+
+    main()
+
+    assert sorted(os.listdir(tmp_path)) == ["foo1.txt", "foo2.txt"]
+
+
+def test_headless_yes_applies_rename(tmp_path, monkeypatch):
+    """`--yes` should apply the rename immediately without opening the TUI."""
+    _make_files(tmp_path, ["foo1.txt", "foo2.txt"])
+
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "foo", "bar", "--yes"])
+
+    main()
+
+    assert sorted(os.listdir(tmp_path)) == ["bar1.txt", "bar2.txt"]
+
+
+def test_headless_no_matches(tmp_path, monkeypatch):
+    """Headless mode should report and exit cleanly when nothing matches."""
+    _make_files(tmp_path, ["baz.txt"])
+
+    monkeypatch.setattr("sys.argv", ["renux", str(tmp_path), "foo", "bar", "--yes"])
+
+    main()
+
+    assert sorted(os.listdir(tmp_path)) == ["baz.txt"]


### PR DESCRIPTION
Closes #47 

## What

- Add `-y`/`--yes` and `--dry-run` flags to apply or preview renames directly from the CLI without opening the TUI
- Add `--undo`/`--redo` flags to revert/reapply the last headless rename without opening the TUI
- Add repeatable `--exclude PATTERN` (exact name or glob) to skip specific files, mirrored in the TUI as a new comma-separated exclude field in the form

## Why

- `renux` always launched the interactive TUI regardless of arguments, which blocked any scripting, CI, or cron use case
- Once headless apply/undo/redo existed, the TUI's per-file exclusion (click-to-disable) had no CLI equivalent, so exclusion by pattern was added and reflected in both interfaces for parity

## Notes

- Headless renames read/write the same backup file (`backup.py`) used by the TUI, so a headless `--yes` can be undone from the TUI and vice versa
- New tests in `tests/test_cli.py` cover dry-run, apply, no-matches, undo, redo, and exclude; 54 tests passing, black/mypy clean
- README updated with the new flags